### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2.1.4
+
+    - name: npm install
+      run: npm install
+
+    - name: npm run build
+      run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2.1.4
+
+    - name: npm install
+      run: npm install
+
+    - name: npm run test
+      run: npm run test
+


### PR DESCRIPTION
Adds a continuous integration workflow that automatically triggers on
1. Commits to master
2. Pull requests created targeting master

The `build` job runs `npm install` and `npm build`.

The `test` job runs `npm install` and `npm test`.

Unfortunately, `test` is failing at this time, but this doesn't seem related to the workflow. I'm able to reproduce those failures locally.