### PR TITLE
Sidebar: Allow customized routes

### DIFF
--- a/src/components/sidebar/VuestroSidebar.vue
+++ b/src/components/sidebar/VuestroSidebar.vue
@@ -37,11 +37,11 @@
     <transition name="vuestro-sidebar" mode="out-in" @after-leave="afterLeave">
       <vuestro-sidebar-menu v-if="!localMini"
                             :role="role"
-                            :routes="$router.options.routes"
+                            :routes="routes"
                             @click="toggleSidebar"></vuestro-sidebar-menu>
       <vuestro-mini-sidebar-menu v-else
                                  :role="role"
-                                 :routes="$router.options.routes"
+                                 :routes="routes"
                                  @click="toggleSidebar">
       </vuestro-mini-sidebar-menu>
     </transition>
@@ -74,10 +74,15 @@ export default {
     role: { type: [String, Array], default: '' }, // user role
     link: { type: String, default: '' }, // user link
     mini: { type: Boolean, default: false }, // mini sidebar
+    routes: {
+      type: Array,
+      default: function() {
+        return _.cloneDeep(this.$router.options.routes);
+      }
+    },
   },
   data() {
     return {
-      routes: _.cloneDeep(this.$router.options.routes),
       geoColor: '',
       localMini: this.mini,
       debounceAuto: false,

--- a/src/pages/Navigation.vue
+++ b/src/pages/Navigation.vue
@@ -1,0 +1,9 @@
+<template>
+  <router-view></router-view>
+</template>
+
+<script>
+export default {
+  name: 'Navigation',
+}
+</script>

--- a/src/pages/NavigationSidebar.vue
+++ b/src/pages/NavigationSidebar.vue
@@ -1,0 +1,78 @@
+<template>
+  <vuestro-container no-wrap column shrink>
+    <vuestro-card cols="0" stretch>
+      <template #heading>
+        VuestroSidebar
+      </template>
+      <p>
+        Use the VuestroSidebar to show a navigation menu on the side of the page. It automatically retrieves routes from the app's router.
+      </p>
+      <p>
+        Use the following <code>meta</code> properties to customize the display of a route in the sidebar.
+      </p>
+
+<vuestro-editor lang="javascript" :options="editorOptions">{
+  meta: {
+    // Display name in the sidebar.
+    title: 'Dashboard',
+    // To hide a route from the sidebar, set this to false.
+    sidebar: true,
+    // Icon to show in the sidebar
+    icon: 'tachometer-alt',
+  },
+  name: 'dashboard',
+  path: '/dashboard',
+  component: Dashboard,
+}</vuestro-editor>
+    </vuestro-card>
+
+    <vuestro-card cols="0" stretch>
+      <p>
+        By default, VuestroSidebar looks at the routes in <code>this.$router.options.routes</code>. You may set the <code>routes</code> prop to override this. For example, let's create a sidebar that only shows the children of the <strong>Charts</strong> route.
+      </p>
+
+      <vuestro-container>
+        <vuestro-card cols="4">
+          <vuestro-panel style="--vuestro-panel-bg: var(--vuestro-purple); --vuestro-panel-fg: var(--vuestro-text-color-inverse)">
+            <vuestro-sidebar :routes="routes"></vuestro-sidebar>
+          </vuestro-panel>
+        </vuestro-card>
+        <vuestro-card cols="8">
+          <vuestro-editor lang="javascript" :options="editorOptions">Vue.component('my-page', {
+  template: '&lt;vuestro-sidebar :routes="routes"&gt;&lt;/vuestro-sidebar&gt;'
+  data() {
+    return {
+      routes: _.cloneDeep(this.$router.options.routes.find(r => r.name === 'charts').children),
+    };
+  }
+})</vuestro-editor>
+        </vuestro-card>
+      </vuestro-container>
+    </vuestro-card>
+  </vuestro-container>
+</template>
+
+<script>
+import VuestroContainer from '../components/VuestroContainer.vue';
+import VuestroPanel from '../components/VuestroPanel.vue';
+export default {
+  components: {
+    VuestroPanel,
+    VuestroContainer
+  },
+  name: 'NavigationSidebar',
+  data() {
+    return {
+      routes: _.cloneDeep(this.$router.options.routes.find(r => r.name === 'charts').children),
+      editorOptions: {
+        readOnly: true,
+        useWorker: false,
+        maxLines: 20,
+      },
+    }
+  },
+  mounted() {
+    console.log(this.$router.options.routes.find(r => r.name === 'sidebar'));
+  },
+}
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -42,6 +42,8 @@ import PluginMixins from './pages/PluginMixins';
 import PluginColors from './pages/PluginColors';
 import PluginFilters from './pages/PluginFilters';
 import InputsEditor from './pages/InputsEditor';
+import Navigation from './pages/Navigation';
+import NavigationSidebar from './pages/NavigationSidebar';
 import Example from './pages/Example';
 import ExampleForms from './pages/ExampleForms';
 import Settings from './pages/Settings';
@@ -399,6 +401,27 @@ export default new Router({
           component: InputsEditor,
         },
       ]
+    },
+    {
+      meta: {
+        title: 'Navigation',
+        sidebar: true,
+        icon: 'bars',
+      },
+      name: 'navigation',
+      path: '/navigation',
+      component: Navigation,
+      children: [
+        {
+          meta: {
+            title: 'Sidebar',
+            sidebar: true,
+          },
+          name: 'sidebar',
+          path: 'sidebar',
+          component: NavigationSidebar,
+        },
+      ],
     },
     {
       meta: {


### PR DESCRIPTION
Allow the user to specify the routes to include in the VuestroSidebar.
By default, the sidebar uses $router.options.routes. This allows a user
to select a subset of routes, rather than using the entire route tree.

Essentially, I wanted to show a sidebar with a different root. Instead of showing a sidebar for the entire router, I wanted to show a sidebar for a subset of the routing table.