### PR TITLE
Sidebar: Add roles to SubRoutes

### DIFF
--- a/src/components/sidebar/VuestroSidebarItem.vue
+++ b/src/components/sidebar/VuestroSidebarItem.vue
@@ -15,7 +15,7 @@
           </template>
         </div>
       </a>
-      <vuestro-sub-routes :show="active" :route="route"></vuestro-sub-routes>
+      <vuestro-sub-routes :show="active" :role="role" :route="route"></vuestro-sub-routes>
     </template>
     <!--NO CHILDREN-->
     <router-link v-else
@@ -49,6 +49,7 @@ export default {
     VuestroSubRoutes,
   },
   props: {
+    role: { type: [String, Array], default: () => [] }, // user role
     route: { type: Object, required: true },
   },
   data() {

--- a/src/components/sidebar/VuestroSidebarMenu.vue
+++ b/src/components/sidebar/VuestroSidebarMenu.vue
@@ -6,6 +6,7 @@
                                 (route.meta.sidebar || route.meta.sidebarBottom) &&
                                 (route.meta.role ? (route.meta.role === role || role.indexOf(route.meta.role) > -1):true) &&
                                 (!route.meta.showFunc || route.meta.showFunc())"
+                          :role="role"
                           :route="route">
     </vuestro-sidebar-item>
   </div>

--- a/src/components/sidebar/VuestroSubRoutes.vue
+++ b/src/components/sidebar/VuestroSubRoutes.vue
@@ -2,7 +2,10 @@
   <transition name="vuestro-sub-routes" mode="out-in">
     <ul v-if="show" class="vuestro-sub-routes">
       <template v-for="subroute in route.children">
-        <li v-if="subroute.meta.sidebar" class="vuestro-sub-routes-item" :key="subroute.path">
+        <li v-if="subroute.meta.sidebar && 
+                  (subroute.meta.role ? (subroute.meta.role === role || role.indexOf(subroute.meta.role) > -1):true)" 
+            class="vuestro-sub-routes-item" 
+            :key="subroute.path">
           <router-link v-if="toPath"
                        :to="{ path: route.path + '/' + subroute.path }"
                        exact-active-class="vuestro-router-link-exact-active"
@@ -26,6 +29,7 @@
 export default {
   name: 'VuestroSubRoutes',
   props: {
+    role: { type: [String, Array], default: () => [] }, // user role
     route: { type: Object, required: true },
     show: { type: Boolean, default: true },
     toPath: { type: Boolean, default: false }, // build a path manually


### PR DESCRIPTION
The sidebar menu was already able to check the meta.role of a given route, but it was not able to check the meta.role of a subroute. This is useful for hiding individual subroutes within a route by user role.